### PR TITLE
update old book references to the second edition of the book

### DIFF
--- a/error_handling/errors2.rs
+++ b/error_handling/errors2.rs
@@ -68,5 +68,5 @@ mod tests {
 // `Err(something)`. This pattern is very common in Rust, though, so there's
 // a `?` operator that does pretty much what you would make that match statement
 // do for you! Take a look at this section of the Error Handling chapter:
-// https://doc.rust-lang.org/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-
+// https://doc.rust-lang.org/stable/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
 // and give it a try!

--- a/error_handling/errorsn.rs
+++ b/error_handling/errorsn.rs
@@ -124,7 +124,7 @@ impl error::Error for CreationError {
 // can be returned from the same function because all errors act the same
 // since they all implement the `error::Error` trait.
 // Check out this section of the book:
-// https://doc.rust-lang.org/stable/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-
+// https://doc.rust-lang.org/stable/book/second-edition/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator
 
 // Another another hint: Note that because the `?` operator returns
 // the *unwrapped* value in the `Ok` case, if we want to return a `Result` from

--- a/primitive_types/primitive_types3.rs
+++ b/primitive_types/primitive_types3.rs
@@ -39,8 +39,9 @@ fn main() {
 
 
 // There's a shorthand to initialize Arrays with a certain size that does not 
-// require you to type in 100 items (but you certainly can if you want!)
-// Check out the Primitive Types -> Arrays section of the book:
-// https://doc.rust-lang.org/stable/book/second-edition/ch03-02-data-types.html#arrays
+// require you to type in 100 items (but you certainly can if you want!).
+// For example, you can do:
+// let array = ["Are we there yet?"; 10];
+
 // Bonus: what are some other things you could have that would return true
 // for `a.len() >= 100`?

--- a/primitive_types/primitive_types4.rs
+++ b/primitive_types/primitive_types4.rs
@@ -38,12 +38,12 @@ fn main() {
 
 
 
-// Take a look at the Primitive Types -> Slices section of the book:
-// http://doc.rust-lang.org/stable/book/primitive-types.html#slices
+// Take a look at the Understanding Ownership -> Slices -> Other Slices section of the book:
+// https://doc.rust-lang.org/stable/book/second-edition/ch04-03-slices.html#other-slices
 // and use the starting and ending indices of the items in the Array
 // that you want to end up in the slice.
 
 // If you're curious why the right hand of the `==` comparison does not
 // have an ampersand for a reference since the left hand side is a
-// reference, take a look at the Deref coercions chapter:
-// http://doc.rust-lang.org/stable/book/deref-coercions.html
+// reference, take a look at the Deref coercions section of the book:
+// https://doc.rust-lang.org/stable/book/second-edition/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods

--- a/primitive_types/primitive_types5.rs
+++ b/primitive_types/primitive_types5.rs
@@ -38,8 +38,8 @@ fn main() {
 
 
 
-// Take a look at the Primitive Types -> Tuples section of the book:
-// http://doc.rust-lang.org/stable/book/primitive-types.html#tuples
-// Particularly the part about "destructuring lets". You'll need to
-// make a pattern to bind `name` and `age` to the appropriate parts
+// Take a look at the Data Types -> The Tuple Type section of the book:
+// https://doc.rust-lang.org/stable/book/second-edition/ch03-02-data-types.html#the-tuple-type
+// Particularly the part about destructuring (second to last example in the section). 
+// You'll need to make a pattern to bind `name` and `age` to the appropriate parts
 // of the tuple. You can do it!!

--- a/primitive_types/primitive_types6.rs
+++ b/primitive_types/primitive_types6.rs
@@ -39,6 +39,7 @@ fn main() {
 
 
 // While you could use a destructuring `let` for the tuple here, try 
-// indexing into it instead, as explained here:
-// http://doc.rust-lang.org/stable/book/primitive-types.html#tuple-indexing
+// indexing into it instead, as explained in the last example of the 
+// Data Types -> The Tuple Type section of the book:
+// https://doc.rust-lang.org/stable/book/second-edition/ch03-02-data-types.html#the-tuple-type
 // Now you have another tool in your toolbox!

--- a/standard_library_types/iterator3.rs
+++ b/standard_library_types/iterator3.rs
@@ -114,7 +114,8 @@ mod tests {
 
 
 
-// Minor hint: In each of the two cases in the match in main, you can create x with either a 'turbofish' or by hinting the type of x to the compiler. You may try both.
+// Minor hint: In each of the two cases in the match in main, you can create x with either 
+// a 'turbofish' or by hinting the type of x to the compiler. You may try both.
 
 
 
@@ -142,4 +143,5 @@ mod tests {
 
 
 
-// Major hint: Have a look at the Iter trait and at the explanation of its collect function. Especially the part about Result is interesting.
+// Major hint: Have a look at the Iter trait and at the explanation of its collect function. 
+// Especially the part about Result is interesting.

--- a/threads/threads1.rs
+++ b/threads/threads1.rs
@@ -45,7 +45,7 @@ fn main() {
 // to **immutable** data. But we want to *change* the number of `jobs_completed`
 // so we'll need to also use another type that will only allow one thread to
 // mutate the data at a time. Take a look at this section of the book:
-// https://doc.rust-lang.org/stable/book/concurrency.html#safe-shared-mutable-state
+// https://doc.rust-lang.org/stable/book/second-edition/ch16-03-shared-state.html#atomic-reference-counting-with-arct
 // and keep scrolling if you'd like more hints :)
 
 


### PR DESCRIPTION
There is a bunch of book references in the hints within exercises that lead to the outdated version of the book (pages have a message "There is a new edition of the book and this is an old link." and require a bunch of digging to find the appropriate section of the book). This change updated the outdated links with the relevant ones, where possible. In one instance (primitive_types3.rs) the content is no longer available in the book, so I provided a direct hint on how to initialize an array of a specified size with values. 